### PR TITLE
Block editor: Move to using a custom REST field instead

### DIFF
--- a/revision-notes.php
+++ b/revision-notes.php
@@ -46,16 +46,24 @@ class HHS_Revision_Notes {
 
 				add_action( "manage_edit-{$post_type}_columns", array( $this, 'add_column' ) );
 				add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'show_column' ), 10, 2 );
+
+				register_rest_field(
+					$post_type,
+					'revision_note',
+					array(
+						'get_callback'    => '__return_empty_string',
+						'update_callback' => function ( $value, $post ) {
+							update_post_meta( $post->ID, 'revision_note', $value );
+						},
+						'schema'          => array(
+							'type' => 'string',
+						),
+					)
+				);
 			}
 		}
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_assets' ) );
-
-		register_meta( 'post', 'revision_note', array(
-			'type' => 'string',
-			'single' => true,
-			'show_in_rest' => true,
-		 ) );
 	}
 
 	public function edit_field() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,47 +1,26 @@
 import { TextareaControl } from '@wordpress/components';
-import { usePrevious } from '@wordpress/compose';
-import { dispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
-import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
  
 const RevisionNotesField = () => {
-	// Revision notes are entered to be saved, not to be edited,
-	// so we use state instead of the actual meta for display value,
-	// resetting it when a post save action happens.
-	const [ revisionNote, setRevisionNote ] = useState('');
-
-	const { isSavingPost } = useSelect(
-		( select ) => ( {
-			isSavingPost:
-				select( 'core/editor' ).isSavingPost() &&
-				! select( 'core/editor' ).isAutosavingPost(),
-		} )
-	);
-	const prevIsSavingPost = usePrevious( isSavingPost );
-
-	useEffect( () => {
-		if (
-			! isSavingPost &&
-			prevIsSavingPost
-		) {
-			setRevisionNote('');
-		}
-	}, [ isSavingPost, prevIsSavingPost ] );
+	// The revision note only needs to be saved anew each time,
+	// and directly editing a core meta field leads to a "dirty" editor state,
+	// so we use a custom REST field instead that always returns an empty string.
+	const { editPost } = useDispatch( 'core/editor' );
+	const revisionNote = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'revision_note' ) );
 
 	return (
 		<PluginPostStatusInfo>
 			<TextareaControl
-				label={__( 'Revision note (optional)', 'revision-notes' )}
-				help={__( 'Enter a brief note about this change', 'revision-notes' )}
-				value={revisionNote}
+				label={ __( 'Revision note (optional)', 'revision-notes' ) }
+				help={ __( 'Enter a brief note about this change', 'revision-notes' ) }
+				value={ revisionNote }
 				onChange={
 					(value) => {
-						setRevisionNote( value );
-
-						dispatch('core/editor').editPost({
-							meta: { revision_note: value },
+						editPost({
+							revision_note: value,
 						});
 					}
 				}


### PR DESCRIPTION
This eliminates the need to track state, which was causing bugs around undo and duplicating previous revision notes if it was otherwise not edited. Also removes the need for useEffect. All around A+ change.

Fixes #9 